### PR TITLE
Remove unnecessary cudaSetDevice calls

### DIFF
--- a/README.md
+++ b/README.md
@@ -417,7 +417,6 @@ void gpu_infer(float* r, float const* u, float const* v, float* c, float alpha,
 and then call it within our RapidsModel `predict` method via:
 
 ```cpp
-rapids::cuda_check(cudaSetDevice(get_device_id()));
 gpu_infer(r.data(), u.data(), v.data(), c.data(), alpha, c.size(),
         u.size(), r.stream());
 ```

--- a/src/model.h
+++ b/src/model.h
@@ -61,7 +61,6 @@ struct RapidsModel : rapids::Model<RapidsSharedState> {
             alpha * u.data()[i] + v.data()[i] + c.data()[i % c.size()];
       }
     } else {
-      rapids::cuda_check(cudaSetDevice(get_device_id()));
       gpu_infer(r.data(), u.data(), v.data(), c.data(), alpha, c.size(),
                 u.size(), r.stream());
     }
@@ -96,7 +95,6 @@ struct RapidsModel : rapids::Model<RapidsSharedState> {
     if constexpr (rapids::IS_GPU_BUILD) {
       if (get_deployment_type() == rapids::GPUDeployment) {
         memory_type = rapids::DeviceMemory;
-        rapids::cuda_check(cudaSetDevice(get_device_id()));
       } else {
         memory_type = rapids::HostMemory;
       }


### PR DESCRIPTION
With RAPIDS-Triton 21.10, it is no longer necessary to explicitly set the device in the backend code in most cases. Remove unnecessary `cudaSetDevice` calls.